### PR TITLE
Review as per requested

### DIFF
--- a/classfile/src/parser.rs
+++ b/classfile/src/parser.rs
@@ -20,7 +20,13 @@ fn parse_index(bytes: Input<'_>) -> IResult<Input<'_>, usize> {
 }
 
 fn parse_magic(bytes: Input<'_>) -> IResult<Input<'_>, &[u8]> {
-    tag([0xCA, 0xFE, 0xBA, 0xBE])(bytes)
+    // consider using constnts with names instead of literals, or link the the spec where these are
+    // used
+
+    // <link to spec>
+    const MAGIC_PREFIX: [u8; 4] = [0xCA, 0xFE, 0xBA, 0xBE];
+
+    tag(MAGIC_PREFIX)(bytes)
 }
 
 fn parse_version(bytes: Input<'_>) -> IResult<Input<'_>, Version> {

--- a/classfile/src/parser.rs
+++ b/classfile/src/parser.rs
@@ -8,30 +8,35 @@ use nom::{
 
 use crate::structure::{AccessFlags, ClassFile, ConstantPoolInfo, Version};
 
+// using typ aliases is ok, but using inferred lifetime parameters can cause major problems later on
+// and is planned to become obsolete in the future, isntead, prefer `Input<'_>` to `Input<'_>`, this
+// makes the owner ship semantics clear here, we're pasisng a reference not an owned value, this is
+// important and should be easy to see (see: rust 2018 idioms in
+// https://doc.rust-lang.org/nightly/nomicon/lifetime-elision.html)
 type Input<'a> = &'a [u8];
 
-fn parse_index(bytes: Input) -> IResult<Input, usize> {
+fn parse_index(bytes: Input<'_>) -> IResult<Input<'_>, usize> {
     map(be_u16, |u: u16| u.into())(bytes)
 }
 
-fn parse_magic(bytes: Input) -> IResult<Input, &[u8]> {
+fn parse_magic(bytes: Input<'_>) -> IResult<Input<'_>, &[u8]> {
     tag([0xCA, 0xFE, 0xBA, 0xBE])(bytes)
 }
 
-fn parse_version(bytes: Input) -> IResult<Input, Version> {
+fn parse_version(bytes: Input<'_>) -> IResult<Input<'_>, Version> {
     let (rest, minor) = be_u16(bytes)?;
     let (rest, major) = be_u16(rest)?;
 
     Ok((rest, Version { major, minor }))
 }
 
-fn parse_class_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
+fn parse_class_info(bytes: Input<'_>) -> IResult<Input<'_>, ConstantPoolInfo> {
     let (rest, name_index) = parse_index(bytes)?;
 
     Ok((rest, ConstantPoolInfo::Class(name_index)))
 }
 
-fn parse_fieldref_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
+fn parse_fieldref_info(bytes: Input<'_>) -> IResult<Input<'_>, ConstantPoolInfo> {
     let (rest, class_index) = parse_index(bytes)?;
     let (rest, name_and_type_index) = parse_index(rest)?;
 
@@ -41,7 +46,7 @@ fn parse_fieldref_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
     ))
 }
 
-fn parse_methodref_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
+fn parse_methodref_info(bytes: Input<'_>) -> IResult<Input<'_>, ConstantPoolInfo> {
     let (rest, class_index) = parse_index(bytes)?;
     let (rest, name_and_type_index) = parse_index(rest)?;
 
@@ -51,7 +56,7 @@ fn parse_methodref_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
     ))
 }
 
-fn parse_interfacemethodref_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
+fn parse_interfacemethodref_info(bytes: Input<'_>) -> IResult<Input<'_>, ConstantPoolInfo> {
     let (rest, class_index) = parse_index(bytes)?;
     let (rest, name_and_type_index) = parse_index(rest)?;
 
@@ -61,39 +66,39 @@ fn parse_interfacemethodref_info(bytes: Input) -> IResult<Input, ConstantPoolInf
     ))
 }
 
-fn parse_string_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
+fn parse_string_info(bytes: Input<'_>) -> IResult<Input<'_>, ConstantPoolInfo> {
     let (rest, string_index) = parse_index(bytes)?;
 
     Ok((rest, ConstantPoolInfo::String(string_index)))
 }
 
-fn parse_integer_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
+fn parse_integer_info(bytes: Input<'_>) -> IResult<Input<'_>, ConstantPoolInfo> {
     let (rest, byte_count) = be_u32(bytes)?;
 
     Ok((rest, ConstantPoolInfo::Integer(byte_count)))
 }
 
-fn parse_float_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
+fn parse_float_info(bytes: Input<'_>) -> IResult<Input<'_>, ConstantPoolInfo> {
     let (rest, byte_count) = be_u32(bytes)?;
 
     Ok((rest, ConstantPoolInfo::Float(byte_count)))
 }
 
-fn parse_long_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
+fn parse_long_info(bytes: Input<'_>) -> IResult<Input<'_>, ConstantPoolInfo> {
     let (rest, high_bytes) = be_u32(bytes)?;
     let (rest, low_bytes) = be_u32(rest)?;
 
     Ok((rest, ConstantPoolInfo::Long(high_bytes, low_bytes)))
 }
 
-fn parse_double_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
+fn parse_double_info(bytes: Input<'_>) -> IResult<Input<'_>, ConstantPoolInfo> {
     let (rest, high_bytes) = be_u32(bytes)?;
     let (rest, low_bytes) = be_u32(rest)?;
 
     Ok((rest, ConstantPoolInfo::Double(high_bytes, low_bytes)))
 }
 
-fn parse_nameandtype_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
+fn parse_nameandtype_info(bytes: Input<'_>) -> IResult<Input<'_>, ConstantPoolInfo> {
     let (rest, name_index) = parse_index(bytes)?;
     let (rest, descriptor_index) = parse_index(rest)?;
 
@@ -103,14 +108,14 @@ fn parse_nameandtype_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
     ))
 }
 
-fn parse_utf_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
+fn parse_utf_info(bytes: Input<'_>) -> IResult<Input<'_>, ConstantPoolInfo> {
     let (rest, length) = be_u16(bytes)?;
     let (rest, utf_bytes) = count(be_u8, length.into())(rest)?;
 
     Ok((rest, ConstantPoolInfo::Utf(length, utf_bytes)))
 }
 
-fn parse_method_handle_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
+fn parse_method_handle_info(bytes: Input<'_>) -> IResult<Input<'_>, ConstantPoolInfo> {
     let (rest, reference_kind) = be_u8(bytes)?;
     let (rest, reference_index) = parse_index(rest)?;
 
@@ -120,13 +125,13 @@ fn parse_method_handle_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
     ))
 }
 
-fn parse_method_type_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
+fn parse_method_type_info(bytes: Input<'_>) -> IResult<Input<'_>, ConstantPoolInfo> {
     let (rest, descriptor_index) = parse_index(bytes)?;
 
     Ok((rest, ConstantPoolInfo::MethodType(descriptor_index)))
 }
 
-fn parse_dynamic_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
+fn parse_dynamic_info(bytes: Input<'_>) -> IResult<Input<'_>, ConstantPoolInfo> {
     let (rest, bootstrap_method_attr_index) = parse_index(bytes)?;
     let (rest, name_and_type_index) = parse_index(rest)?;
 
@@ -136,7 +141,7 @@ fn parse_dynamic_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
     ))
 }
 
-fn parse_invoke_dynamic_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
+fn parse_invoke_dynamic_info(bytes: Input<'_>) -> IResult<Input<'_>, ConstantPoolInfo> {
     let (rest, bootstrap_method_attr_index) = parse_index(bytes)?;
     let (rest, name_and_type_index) = parse_index(rest)?;
 
@@ -146,19 +151,19 @@ fn parse_invoke_dynamic_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
     ))
 }
 
-fn parse_module_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
+fn parse_module_info(bytes: Input<'_>) -> IResult<Input<'_>, ConstantPoolInfo> {
     let (rest, name_index) = parse_index(bytes)?;
 
     Ok((rest, ConstantPoolInfo::Module(name_index)))
 }
 
-fn parse_package_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
+fn parse_package_info(bytes: Input<'_>) -> IResult<Input<'_>, ConstantPoolInfo> {
     let (rest, name_index) = parse_index(bytes)?;
 
     Ok((rest, ConstantPoolInfo::Package(name_index)))
 }
 
-fn parse_constant_pool_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
+fn parse_constant_pool_info(bytes: Input<'_>) -> IResult<Input<'_>, ConstantPoolInfo> {
     let (rest, tag) = be_u8(bytes)?;
 
     match tag {
@@ -183,26 +188,26 @@ fn parse_constant_pool_info(bytes: Input) -> IResult<Input, ConstantPoolInfo> {
     }
 }
 
-fn parse_constant_pool(bytes: Input) -> IResult<Input, Vec<ConstantPoolInfo>> {
+fn parse_constant_pool(bytes: Input<'_>) -> IResult<Input<'_>, Vec<ConstantPoolInfo>> {
     let (rest, cp_count) = be_u16(bytes)?;
 
     count(parse_constant_pool_info, (cp_count - 1).into())(rest)
 }
 
-fn parse_flags(bytes: Input) -> IResult<Input, AccessFlags> {
+fn parse_flags(bytes: Input<'_>) -> IResult<Input<'_>, AccessFlags> {
     map(be_u16, |b: u16| match AccessFlags::from_bits(b) {
         Some(flags) => flags,
         None => panic!("Invalid bytes for access flags"),
     })(bytes)
 }
 
-fn parse_interfaces(bytes: Input) -> IResult<Input, Vec<usize>> {
+fn parse_interfaces(bytes: Input<'_>) -> IResult<Input<'_>, Vec<usize>> {
     let (rest, interface_count) = be_u16(bytes)?;
 
     count(parse_index, interface_count.into())(rest)
 }
 
-pub fn parse_classfile(bytes: Input) -> IResult<Input, ClassFile> {
+pub fn parse_classfile(bytes: Input<'_>) -> IResult<Input<'_>, ClassFile> {
     let (rest, _) = parse_magic(bytes)?;
     let (rest, version) = parse_version(rest)?;
     let (rest, constant_pool) = parse_constant_pool(rest)?;

--- a/classfile/src/structure.rs
+++ b/classfile/src/structure.rs
@@ -23,6 +23,8 @@ pub struct Version {
 
 impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // If the spec doesn't allow unknown versions panicking here would be fine as long as the
+        // type Version internally uphodls that invariant, since its fields are public it doesn't
         let version_string = match &self.major {
             45 => "JDK 1.1",
             46 => "JDK 1.2",
@@ -54,13 +56,17 @@ impl fmt::Display for Version {
     }
 }
 
+// uh just a style thing, those comments weren't aligned so I'd put them above instead idk
 #[derive(Debug)]
 pub enum ConstantPoolInfo {
-    Class(usize),           // name index
-    FieldRef(usize, usize), // class index, name_and_type index
+    // name index
+    Class(usize),
+    // class index, name_and_type index
+    FieldRef(usize, usize),
     MethodRef(usize, usize),
     InterfaceMethodRef(usize, usize),
-    String(usize), // index to utf8 value
+    // index to utf8 value
+    String(usize),
     Integer(u32),
     Float(u32),
     Long(u32, u32),

--- a/jzbldc/src/main.rs
+++ b/jzbldc/src/main.rs
@@ -5,16 +5,18 @@ use classfile::parser;
 type Result<T = (), E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
 
 fn main() -> Result {
+    // - use descriptive variable names, `file_name` instead of `f`
     // - don't use expect/unwrap, especially if inside a Result-returning function, ok_or returns
     //   the result of the closure if the Option is None, turning it into a Result
-    let f = std::env::args()
+    let file_name = std::env::args()
         .nth(1)
         .ok_or("no filepath given, usage `jzbldc <path>`")?;
 
-    let fs = std::fs::read(f)?;
+    // see above regarding names
+    let file_content = std::fs::read(file_name)?;
 
     // see review of classfile
-    let classfile = parser::parse(&fs)?;
+    let classfile = parser::parse(&file_content)?;
 
     println!("{:?}", classfile.access_flags);
     println!("{:?}", classfile.constant_pool[classfile.super_class + 1]);

--- a/jzbldc/src/main.rs
+++ b/jzbldc/src/main.rs
@@ -1,11 +1,20 @@
 use classfile::parser;
 
-fn main() -> std::io::Result<()> {
-    let f = std::env::args().nth(1).expect("expected file path");
+// a convenient type alias which allows using `?` on almost any error type
+// Box<dyn Error> is similar to what anyhow and eyre do
+type Result<T = (), E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
+
+fn main() -> Result {
+    // - don't use expect/unwrap, especially if inside a Result-returning function, ok_or returns
+    //   the result of the closure if the Option is None, turning it into a Result
+    let f = std::env::args()
+        .nth(1)
+        .ok_or("no filepath given, usage `jzbldc <path>`")?;
 
     let fs = std::fs::read(f)?;
 
-    let (_, classfile) = parser::parse_classfile(&fs).expect("correct");
+    // see review of classfile
+    let classfile = parser::parse(&fs)?;
 
     println!("{:?}", classfile.access_flags);
     println!("{:?}", classfile.constant_pool[classfile.super_class + 1]);


### PR DESCRIPTION
:+1: Overall correct usage of data structures and built in functionality, just some minor pain points regarding idioms.
It should be noted that the `Box<dyn Error>` idiom comes at a cost, `?` can also convert between statically known error types in other ways, this just makes it easier and is usually fine for the top level function.

Only remaining clippy lint (`clippy::needless_borrow`), while true, is overly pedantic here.